### PR TITLE
Change time format

### DIFF
--- a/screens/EventScreen.js
+++ b/screens/EventScreen.js
@@ -21,7 +21,7 @@ import ToggleNavigationButton from '../components/ToggleNavigationButton';
 
 const Stack = createStackNavigator();
 
-const dateFormat = 'M-D-YY h:m:s A';
+const dateFormat = 'M-D-YY h:mm:s A';
 
 function Player({uri}) {
     const [error, setError] = useState(false);


### PR DESCRIPTION
const dateFormat = 'M-D-YY h:m:s A';

change to:

const dateFormat = 'M-D-YY h:mm:s A';

(without this events were showing '1**:2:**1 PM' and '12:50:13 PM'